### PR TITLE
Fix IE8 compatibility issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = function(moment){
     formats: {
       date: 'L',
       time: 'LT',
-      default: 'lll',
+      'default': 'lll',
       header: 'MMMM YYYY',
       footer: 'LL',
       weekday: function(day, culture) {


### PR DESCRIPTION
Legacy browsers break on the `default` object key because it's a reserved word. Defining it as a string key solves the problem.